### PR TITLE
cleaned state math, removed infer_offsets

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -20,7 +20,8 @@ use syn::{
 #[derive(Debug, FromMeta)]
 struct BlockArgs {
     base_addr: LitInt,
-    infer_offsets: bool,
+    #[darling(default)]
+    auto_increment: bool,
     entitlements: PathArray,
 }
 
@@ -308,7 +309,7 @@ fn process_state(
         let ident = &s.ident;
         quote_spanned! { span =>
             const _: () = assert!(
-                (States::#ident as u32) <= u32::MAX >> (32 - #field_width),
+                ((States::#ident as u32) >> #field_width) == 0,
                 #msg,
             );
         }

--- a/proto-hal/src/lib.rs
+++ b/proto-hal/src/lib.rs
@@ -210,7 +210,7 @@ mod tests {
 
         #[block(
             base_addr = 0x4002_1000,
-            infer_offsets,
+            auto_increment,
             entitlements = [super::ahb::cordic_en::Enabled]
         )]
         mod cordic {


### PR DESCRIPTION
Refactored maximum allowed state value math to fit within field widths. Made Block more consistent by using auto_increment instead of infer_offsets.