### PR TITLE
Consolidate `Writer` and `TransitionBuilder`

### DIFF
--- a/ir/src/structures/field.rs
+++ b/ir/src/structures/field.rs
@@ -122,7 +122,7 @@ impl Field {
         match &self.access {
             Access::ReadWrite(ReadWrite::Symmetrical(access)) => {
                 if let Numericity::Enumerated { variants } = &access.numericity {
-                    if variants.values().find(|variant| variant.inert).is_some() {
+                    if variants.values().any(|variant| variant.inert) {
                         None
                     } else {
                         Some(access)

--- a/ir/src/structures/variant.rs
+++ b/ir/src/structures/variant.rs
@@ -13,6 +13,7 @@ use super::entitlement::Entitlement;
 pub struct Variant {
     pub ident: Ident,
     pub bits: u32,
+    pub inert: bool,
     pub entitlements: Entitlements,
     pub docs: Vec<String>,
 }
@@ -22,8 +23,16 @@ impl Variant {
         Self {
             ident: Ident::new(ident.as_ref(), Span::call_site()),
             bits,
+            inert: false,
             entitlements: Entitlements::new(),
             docs: Vec::new(),
+        }
+    }
+
+    pub fn inert(self) -> Self {
+        Self {
+            inert: true,
+            ..self
         }
     }
 

--- a/proto-hal/src/stasis.rs
+++ b/proto-hal/src/stasis.rs
@@ -108,12 +108,15 @@ pub trait Conjure {
 }
 
 pub trait Emplace<Writer> {
-    fn set(w: &mut Writer);
+    fn set(&self, w: &mut Writer);
 }
+
+// Effectively "!Unresolved".
+pub trait Corporeal {}
 
 pub trait Position<T> {}
 pub trait Outgoing<T>: Position<T> {}
-pub trait Incoming<T>: Position<T> {
+pub trait Incoming<T>: Position<T> + Corporeal + Conjure {
     type Raw;
     const RAW: Self::Raw;
 }
@@ -125,9 +128,24 @@ impl Conjure for Unresolved {
 }
 
 impl<Writer> Emplace<Writer> for Unresolved {
-    fn set(#[expect(unused)] w: &mut Writer) {
+    fn set(&self, #[expect(unused)] w: &mut Writer) {
         // do nothing
     }
 }
 
 impl<T> Position<T> for Unresolved {}
+
+impl Conjure for Unavailable {
+    unsafe fn conjure() -> Self {
+        Self
+    }
+}
+
+impl<Writer> Emplace<Writer> for Unavailable {
+    fn set(&self, #[expect(unused)] w: &mut Writer) {
+        // do nothing
+    }
+}
+
+impl Corporeal for Unavailable {}
+impl<T> Position<T> for Unavailable {}

--- a/tests/abstract/src/lib.rs
+++ b/tests/abstract/src/lib.rs
@@ -62,7 +62,9 @@ mod tests {
             fn unsafe_write() {
                 let _lock = LOCK.lock().unwrap();
 
-                unsafe { foo0::write_from_zero_untracked(|w| w.a().v2()) };
+                unsafe {
+                    foo0::write_from_zero_untracked(|w| w.a(foo0::a::WriteVariant::V2 as u32))
+                };
                 assert!(unsafe { foo0::read_untracked().a().is_v2() });
             }
 
@@ -70,10 +72,12 @@ mod tests {
             fn unsafe_modify() {
                 let _lock = LOCK.lock().unwrap();
 
-                unsafe { foo0::write_from_zero_untracked(|w| w.a().v3()) };
+                unsafe {
+                    foo0::write_from_zero_untracked(|w| w.a(foo0::a::WriteVariant::V3 as u32))
+                };
                 unsafe {
                     foo0::modify_untracked(|r, w| {
-                        w.a().variant(foo0::a::Variant::from_bits(r.a() as u32 + 1))
+                        w.a(foo0::a::Variant::from_bits(r.a() as u32 + 1) as u32)
                     })
                 };
 

--- a/tests/g4/model/src/crc/cr.rs
+++ b/tests/g4/model/src/crc/cr.rs
@@ -1,7 +1,7 @@
 pub mod polysize;
-pub mod reset;
 pub mod rev_in;
 pub mod rev_out;
+pub mod rst;
 
 use proto_hal_build::ir::structures::register::Register;
 
@@ -10,7 +10,7 @@ pub fn generate() -> Register {
         "cr",
         8,
         [
-            reset::generate(),
+            rst::generate(),
             polysize::generate(),
             rev_in::generate(),
             rev_out::generate(),

--- a/tests/g4/model/src/crc/cr/rst.rs
+++ b/tests/g4/model/src/crc/cr/rst.rs
@@ -8,12 +8,12 @@ use proto_hal_build::ir::{
 
 pub fn generate() -> Field {
     Field::new(
-        "reset",
+        "rst",
         0,
         1,
         Access::read_write_asymmetrical(
             Numericity::enumerated([Variant::new("Clear", 0), Variant::new("Set", 1)]),
-            Numericity::enumerated([Variant::new("Set", 1)]),
+            Numericity::enumerated([Variant::new("Noop", 0).inert(), Variant::new("Set", 1)]),
         ),
     )
 }


### PR DESCRIPTION
Read `notes.md` for information about this change.

# Issues

The only issue this change introduces that I am aware of is that a fair amount of code generated that can never be used, namely the dynamic related code for resolvable fields which are entitled to. This code should be culled by tracking which fields are entitled to.