### PR TITLE
modify requires critical section

### DIFF
--- a/proto-hal/Cargo.toml
+++ b/proto-hal/Cargo.toml
@@ -12,6 +12,7 @@ defmt = ["dep:defmt"]
 
 [dependencies]
 arbitrary-int = "1.2.7"
+critical-section = "1.2.0"
 defmt = { version = "0.3.10", optional = true }
 
 [dev-dependencies]

--- a/proto-hal/src/lib.rs
+++ b/proto-hal/src/lib.rs
@@ -10,6 +10,8 @@ pub mod ir_utils;
 pub mod prelude;
 pub mod stasis;
 
+pub use critical_section;
+
 /// Types that encapsulate a resource that can be configured to be
 /// in a "reset" state implement this trait.
 pub trait IntoReset {

--- a/tests/abstract/Cargo.toml
+++ b/tests/abstract/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2024"
 [dependencies]
 proto-hal = { path = "../../proto-hal" }
 
+[dev-dependencies]
+critical-section = { version = "1.2.0", features = ["std"] }
+
 [build-dependencies]
 model = { package = "abstract-model", path = "model" }
 proto-hal-build = { path = "../../proto-hal-build" }

--- a/tests/abstract/src/lib.rs
+++ b/tests/abstract/src/lib.rs
@@ -37,10 +37,6 @@ mod tests {
 
             static mut MOCK_FOO: u32 = u32::MAX;
 
-            // the unsafe interface tests interact with a shared resource. in order for this to be sound, the tests
-            // must run sequentially, which is achieved by requiring acquisition of this lock.
-            static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
             #[unsafe(export_name = "__PROTO_HAL_ADDR_OF_FOO")]
             fn addr_of() -> usize {
                 (&raw const MOCK_FOO).addr()
@@ -53,31 +49,32 @@ mod tests {
 
             #[test]
             fn unsafe_read() {
-                let _lock = LOCK.lock().unwrap();
-                unsafe { MOCK_FOO = foo0::a::Variant::V1 as _ };
-                assert!(unsafe { foo0::read_untracked().a().is_v1() });
+                critical_section::with(|_| {
+                    unsafe { MOCK_FOO = foo0::a::Variant::V1 as _ };
+                    assert!(unsafe { foo0::read_untracked().a().is_v1() });
+                });
             }
 
             #[test]
             fn unsafe_write() {
-                let _lock = LOCK.lock().unwrap();
-
-                unsafe { foo0::write_from_zero_untracked(|w| w.a(foo0::a::WriteVariant::V2)) };
-                assert!(unsafe { foo0::read_untracked().a().is_v2() });
+                critical_section::with(|_| {
+                    unsafe { foo0::write_from_zero_untracked(|w| w.a(foo0::a::WriteVariant::V2)) };
+                    assert!(unsafe { foo0::read_untracked().a().is_v2() });
+                });
             }
 
             #[test]
             fn unsafe_modify() {
-                let _lock = LOCK.lock().unwrap();
+                critical_section::with(|cs| {
+                    unsafe { foo0::write_from_zero_untracked(|w| w.a(foo0::a::WriteVariant::V3)) };
+                    unsafe {
+                        foo0::modify_untracked(cs, |r, w| {
+                            w.a(foo0::a::Variant::from_bits(r.a() as u32 + 1))
+                        })
+                    };
 
-                unsafe { foo0::write_from_zero_untracked(|w| w.a(foo0::a::WriteVariant::V3)) };
-                unsafe {
-                    foo0::modify_untracked(|r, w| {
-                        w.a(foo0::a::Variant::from_bits(r.a() as u32 + 1))
-                    })
-                };
-
-                assert!(unsafe { foo0::read_untracked().a().is_v4() });
+                    assert!(unsafe { foo0::read_untracked().a().is_v4() });
+                });
             }
         }
     }

--- a/tests/g4/Cargo.toml
+++ b/tests/g4/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2024"
 [dependencies]
 proto-hal = { path = "../../proto-hal" }
 
+[dev-dependencies]
+critical-section = { version = "1.2.0", features = ["std"] }
+
 [build-dependencies]
 model = { package = "g4-model", path = "model" }
 proto-hal-build = { path = "../../proto-hal-build" }

--- a/tests/g4/src/lib.rs
+++ b/tests/g4/src/lib.rs
@@ -5,7 +5,6 @@ include!(concat!(env!("OUT_DIR"), "/hal.rs"));
 #[cfg(test)]
 mod tests {
     extern crate std;
-    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     static mut MOCK_RCC: [u32; 40] = [0; 40];
 
@@ -19,7 +18,6 @@ mod tests {
 
         use crate::{cordic, rcc};
 
-        use super::LOCK;
         static mut MOCK_CORDIC: [u32; 3] = [0x0000_0050, 0, 0];
 
         #[unsafe(export_name = "__PROTO_HAL_ADDR_OF_CORDIC")]
@@ -29,86 +27,85 @@ mod tests {
 
         #[test]
         fn basic() {
-            let _lock = LOCK.lock().unwrap();
+            critical_section::with(|cs| {
+                let p = unsafe { crate::peripherals() };
 
-            let p = unsafe { crate::peripherals() };
+                let rcc::ahb1enr::States { cordicen, .. } =
+                    rcc::ahb1enr::modify(cs, |_, w| w.cordicen(p.rcc.ahb1enr.cordicen).enabled());
+                let cordic = p.cordic.unmask(cordicen);
 
-            let rcc::ahb1enr::States { cordicen, .. } =
-                rcc::ahb1enr::modify(|_, w| w.cordicen(p.rcc.ahb1enr.cordicen).enabled());
-            let cordic = p.cordic.unmask(cordicen);
+                cordic::csr::modify(cs, |_, w| {
+                    w.func(cordic.csr.func)
+                        .sqrt()
+                        .scale(cordic.csr.scale)
+                        .preserve()
+                });
 
-            cordic::csr::modify(|_, w| {
-                w.func(cordic.csr.func)
-                    .sqrt()
-                    .scale(cordic.csr.scale)
-                    .preserve()
-            });
+                assert!({
+                    let csr = unsafe { cordic::csr::read_untracked() };
 
-            assert!({
-                let csr = unsafe { cordic::csr::read_untracked() };
+                    csr.func().is_sqrt() && csr.scale().is_n0()
+                });
 
-                csr.func().is_sqrt() && csr.scale().is_n0()
-            });
+                unsafe { cordic::csr::write_from_reset_untracked(|w| w) };
 
-            unsafe { cordic::csr::write_from_reset_untracked(|w| w) };
+                assert!({
+                    let csr = unsafe { cordic::csr::read_untracked() };
 
-            assert!({
-                let csr = unsafe { cordic::csr::read_untracked() };
-
-                csr.func().is_cos() && csr.scale().is_n0() && csr.precision().is_p20()
+                    csr.func().is_cos() && csr.scale().is_n0() && csr.precision().is_p20()
+                });
             });
         }
 
         #[test]
         fn wdata() {
-            let _lock = LOCK.lock().unwrap();
+            critical_section::with(|cs| {
+                let p = unsafe { crate::peripherals() };
 
-            let p = unsafe { crate::peripherals() };
+                let rcc::ahb1enr::States { cordicen, .. } =
+                    rcc::ahb1enr::modify(cs, |_, w| w.cordicen(p.rcc.ahb1enr.cordicen).enabled());
+                let cordic = p.cordic.unmask(cordicen);
 
-            let rcc::ahb1enr::States { cordicen, .. } =
-                rcc::ahb1enr::modify(|_, w| w.cordicen(p.rcc.ahb1enr.cordicen).enabled());
-            let cordic = p.cordic.unmask(cordicen);
+                let mut arg = cordic.wdata.arg.unmask(cordic.csr.argsize);
 
-            let mut arg = cordic.wdata.arg.unmask(cordic.csr.argsize);
+                cordic::wdata::write(|w| w.arg(&mut arg, 0xdeadbeefu32));
 
-            cordic::wdata::write(|w| w.arg(&mut arg, 0xdeadbeefu32));
-
-            assert_eq!(unsafe { MOCK_CORDIC }[1], 0xdeadbeef);
+                assert_eq!(unsafe { MOCK_CORDIC }[1], 0xdeadbeef);
+            });
         }
 
         #[test]
         fn rdata() {
-            let _lock = LOCK.lock().unwrap();
+            critical_section::with(|cs| {
+                unsafe { MOCK_CORDIC[2] = 0xdeadbeef };
 
-            unsafe { MOCK_CORDIC[2] = 0xdeadbeef };
+                let p = unsafe { crate::peripherals() };
 
-            let p = unsafe { crate::peripherals() };
+                let rcc::ahb1enr::States { cordicen, .. } =
+                    rcc::ahb1enr::modify(cs, |_, w| w.cordicen(p.rcc.ahb1enr.cordicen).enabled());
+                let cordic = p.cordic.unmask(cordicen);
 
-            let rcc::ahb1enr::States { cordicen, .. } =
-                rcc::ahb1enr::modify(|_, w| w.cordicen(p.rcc.ahb1enr.cordicen).enabled());
-            let cordic = p.cordic.unmask(cordicen);
+                let cordic::csr::States { ressize, .. } =
+                    cordic::csr::modify(cs, |_, w| w.ressize(cordic.csr.ressize).q15());
 
-            let cordic::csr::States { ressize, .. } =
-                cordic::csr::modify(|_, w| w.ressize(cordic.csr.ressize).q15());
+                // multiple fields are entitled to these states, so the state must be explicitly frozen.
+                let (_, [res0_nres_ent, res1_nres_ent]) = cordic.csr.nres.freeze();
+                let (_, [res0_ressize_ent, res1_ressize_ent]) = ressize.freeze();
 
-            // multiple fields are entitled to these states, so the state must be explicitly frozen.
-            let (_, [res0_nres_ent, res1_nres_ent]) = cordic.csr.nres.freeze();
-            let (_, [res0_ressize_ent, res1_ressize_ent]) = ressize.freeze();
+                let (mut res0, mut res1) = (
+                    cordic.rdata.res0.unmask(res0_nres_ent, res0_ressize_ent),
+                    cordic.rdata.res1.unmask(res1_nres_ent, res1_ressize_ent),
+                );
 
-            let (mut res0, mut res1) = (
-                cordic.rdata.res0.unmask(res0_nres_ent, res0_ressize_ent),
-                cordic.rdata.res1.unmask(res1_nres_ent, res1_ressize_ent),
-            );
-
-            assert_eq!(cordic::rdata::read().res0(&mut res0), 0xbeef);
-            assert_eq!(cordic::rdata::read().res1(&mut res1), 0xdead);
+                assert_eq!(cordic::rdata::read().res0(&mut res0), 0xbeef);
+                assert_eq!(cordic::rdata::read().res1(&mut res1), 0xdead);
+            });
         }
     }
 
     mod crc {
         use crate::{crc, rcc};
 
-        use super::LOCK;
         static mut MOCK_CRC: [u32; 2] = [0, 0];
 
         #[unsafe(export_name = "__PROTO_HAL_ADDR_OF_CRC")]
@@ -118,36 +115,36 @@ mod tests {
 
         #[test]
         fn basic() {
-            let _lock = LOCK.lock().unwrap();
+            critical_section::with(|cs| {
+                let p = unsafe { crate::peripherals() };
 
-            let p = unsafe { crate::peripherals() };
+                let rcc::ahb1enr::States { crcen, .. } =
+                    rcc::ahb1enr::modify(cs, |_, w| w.crcen(p.rcc.ahb1enr.crcen).enabled());
+                let crc = p.crc.unmask(crcen);
 
-            let rcc::ahb1enr::States { crcen, .. } =
-                rcc::ahb1enr::modify(|_, w| w.crcen(p.rcc.ahb1enr.crcen).enabled());
-            let crc = p.crc.unmask(crcen);
+                let crc::idr::States { idr } =
+                    crc::idr::write(|w| w.idr(crc.idr.idr).value::<0xdeadbeef>());
 
-            let crc::idr::States { idr } =
-                crc::idr::write(|w| w.idr(crc.idr.idr).value::<0xdeadbeef>());
-
-            assert_eq!(idr.value(), unsafe { MOCK_CRC[1] });
+                assert_eq!(idr.value(), unsafe { MOCK_CRC[1] });
+            });
         }
 
         #[test]
         fn inert() {
-            let _lock = LOCK.lock().unwrap();
+            critical_section::with(|cs| {
+                let p = unsafe { crate::peripherals() };
 
-            let p = unsafe { crate::peripherals() };
+                let rcc::ahb1enr::States { crcen, .. } =
+                    rcc::ahb1enr::modify(cs, |_, w| w.crcen(p.rcc.ahb1enr.crcen).enabled());
+                let crc = p.crc.unmask(crcen);
 
-            let rcc::ahb1enr::States { crcen, .. } =
-                rcc::ahb1enr::modify(|_, w| w.crcen(p.rcc.ahb1enr.crcen).enabled());
-            let crc = p.crc.unmask(crcen);
-
-            // "rst" need not be specified because it has an inert variant
-            crc::cr::write(|w| {
-                w.polysize(crc.cr.polysize)
-                    .preserve()
-                    .rev_in(crc.cr.rev_in)
-                    .preserve()
+                // "rst" need not be specified because it has an inert variant
+                crc::cr::write(|w| {
+                    w.polysize(crc.cr.polysize)
+                        .preserve()
+                        .rev_in(crc.cr.rev_in)
+                        .preserve()
+                });
             });
         }
     }


### PR DESCRIPTION
`modify` performs a read-modify-write sequence which must be atomic. Since a single register's fields may be spread across execution contexts, if a preemption occurs resulting in read0-modify0-read1-modify1-write1-write0, then write1 was overridden and the dispatched states are not valid, rendering `modify` unsound. Requiring modifies to be performed within a critical section prevents this.

*In the future, a `modify_all` function could be generated that requires all fields to be specified, which is no longer at risk of a race condition, and would not need a critical section.*