### PR TITLE
access entitlements

### DIFF
--- a/ir/src/access.rs
+++ b/ir/src/access.rs
@@ -1,12 +1,35 @@
 use std::collections::HashSet;
 
-use crate::structures::{entitlement::Entitlement, field::Numericity};
+use crate::structures::{entitlement::Entitlement, field::Numericity, variant::Variant};
 
 #[derive(Debug, Clone)]
 pub struct AccessProperties {
     pub numericity: Numericity,
     pub entitlements: HashSet<Entitlement>,
     pub effects: (),
+}
+
+impl AccessProperties {
+    pub fn enumerated(variants: impl IntoIterator<Item = Variant>) -> Self {
+        Self {
+            numericity: Numericity::enumerated(variants),
+            entitlements: HashSet::new(),
+            effects: (),
+        }
+    }
+
+    pub fn numeric() -> Self {
+        Self {
+            numericity: Numericity::Numeric,
+            entitlements: HashSet::new(),
+            effects: (),
+        }
+    }
+
+    pub fn entitlements(mut self, entitlements: impl IntoIterator<Item = Entitlement>) -> Self {
+        self.entitlements.extend(entitlements);
+        self
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/ir/src/utils/diagnostic.rs
+++ b/ir/src/utils/diagnostic.rs
@@ -12,8 +12,10 @@ pub enum Kind {
     Error,
 }
 
+#[ters]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Context {
+    #[get]
     path: Vec<String>,
 }
 

--- a/tests/abstract/model/src/lib.rs
+++ b/tests/abstract/model/src/lib.rs
@@ -1,6 +1,7 @@
 use proto_hal_build::ir::{
-    access::Access,
+    access::{Access, AccessProperties},
     structures::{
+        entitlement::Entitlement,
         field::{Field, Numericity},
         hal::Hal,
         peripheral::Peripheral,
@@ -15,19 +16,45 @@ pub fn generate() -> Result<Hal, Diagnostics> {
         Peripheral::new(
             "foo",
             0,
-            [Register::new(
-                "foo0",
-                0,
-                [Field::new(
-                    "a",
+            [
+                Register::new(
+                    "foo0",
                     0,
+                    [Field::new(
+                        "a",
+                        0,
+                        4,
+                        Access::read_write(Numericity::enumerated(
+                            (0..6).map(|i| Variant::new(format!("V{i}"), i)),
+                        )),
+                    )
+                    .reset("V3")],
+                ),
+                Register::new(
+                    "foo1",
                     4,
-                    Access::read_write(Numericity::enumerated(
-                        (0..6).map(|i| Variant::new(format!("V{i}"), i)),
-                    )),
-                )
-                .reset("V3")],
-            )],
+                    [
+                        Field::new(
+                            "write_requires_v5",
+                            0,
+                            1,
+                            Access::Write(
+                                AccessProperties::enumerated([Variant::new("Noop", 0)])
+                                    .entitlements([Entitlement::to("foo::foo0::a::V5")]),
+                            ),
+                        ),
+                        Field::new(
+                            "read_requires_v5",
+                            1,
+                            1,
+                            Access::Read(
+                                AccessProperties::numeric()
+                                    .entitlements([Entitlement::to("foo::foo0::a::V5")]),
+                            ),
+                        ),
+                    ],
+                ),
+            ],
         ),
         Peripheral::new(
             "bar",

--- a/tests/abstract/src/lib.rs
+++ b/tests/abstract/src/lib.rs
@@ -94,4 +94,22 @@ mod tests {
             assert_eq!(TypeId::of::<a::Reset>(), TypeId::of::<a::V3>());
         }
     }
+
+    mod entitlements {
+        use crate::foo;
+
+        #[test]
+        fn access() {
+            let mut p = unsafe { crate::peripherals() };
+
+            let foo::foo0::States { a, .. } = foo::foo0::write(|w| w.a(p.foo.foo0.a).v5());
+
+            foo::foo1::write(|w| {
+                w.write_requires_v5(&mut p.foo.foo1.write_requires_v5, &a)
+                    .noop()
+            });
+
+            foo::foo1::read().read_requires_v5(&mut p.foo.foo1.read_requires_v5, &a);
+        }
+    }
 }


### PR DESCRIPTION
Now accesses (read/write) can express entitlements.

This PR also introduces an additional lint for state-wise entitlements in different registers which is currently not supported (but could be!).