### PR TITLE
Move reset specification from Fields to Registers

### DIFF
--- a/tests/abstract/model/src/lib.rs
+++ b/tests/abstract/model/src/lib.rs
@@ -27,9 +27,9 @@ pub fn generate() -> (Hal, Diagnostics) {
                         Access::read_write(Numericity::enumerated(
                             (0..6).map(|i| Variant::new(format!("V{i}"), i)),
                         )),
-                    )
-                    .reset("V3")],
-                ),
+                    )],
+                )
+                .reset(3),
                 Register::new(
                     "foo1",
                     4,

--- a/tests/abstract/src/lib.rs
+++ b/tests/abstract/src/lib.rs
@@ -12,7 +12,7 @@ mod tests {
             let p = unsafe { crate::peripherals() };
 
             assert_eq!(
-                TypeId::of::<crate::foo::foo0::a::Reset>(),
+                TypeId::of::<crate::foo::foo0::a::V3>(),
                 p.foo.foo0.a.type_id(),
             );
         }
@@ -80,18 +80,11 @@ mod tests {
     }
 
     mod fields {
-        use core::any::TypeId;
-
         use crate::foo::foo0::a;
 
         #[test]
         fn offset() {
             assert_eq!(a::OFFSET, 0);
-        }
-
-        #[test]
-        fn reset() {
-            assert_eq!(TypeId::of::<a::Reset>(), TypeId::of::<a::V3>());
         }
     }
 

--- a/tests/g4/model/src/cordic/csr.rs
+++ b/tests/g4/model/src/cordic/csr.rs
@@ -30,4 +30,5 @@ pub fn generate() -> Register {
             rrdy::generate(),
         ],
     )
+    .reset(0x50)
 }

--- a/tests/g4/model/src/cordic/csr/argsize.rs
+++ b/tests/g4/model/src/cordic/csr/argsize.rs
@@ -16,6 +16,5 @@ pub fn generate() -> Field {
             Variant::new("Q15", 1).docs(["1 sign bit, 15 fractional bits."]),
         ])),
     )
-    .reset("Q31")
     .docs(["The value format used for arguments."])
 }

--- a/tests/g4/model/src/cordic/csr/dmaren.rs
+++ b/tests/g4/model/src/cordic/csr/dmaren.rs
@@ -15,5 +15,5 @@ pub fn generate() -> Field {
             Variant::new("Disabled", 0).docs(["No DMA read requests are generated."]),
             Variant::new("Enabled", 1).docs(["Requests are generated on the DMA read channel whenever the [`rrdy`](super::rrdy) flag is set."]),
         ])),
-    ).reset("Disabled")
+    )
 }

--- a/tests/g4/model/src/cordic/csr/dmawen.rs
+++ b/tests/g4/model/src/cordic/csr/dmawen.rs
@@ -18,5 +18,4 @@ pub fn generate() -> Field {
             ]),
         ])),
     )
-    .reset("Disabled")
 }

--- a/tests/g4/model/src/cordic/csr/func.rs
+++ b/tests/g4/model/src/cordic/csr/func.rs
@@ -51,5 +51,4 @@ pub fn generate() -> Field {
         4,
         Access::read_write(Numericity::enumerated(variants)),
     )
-    .reset("cos")
 }

--- a/tests/g4/model/src/cordic/csr/ien.rs
+++ b/tests/g4/model/src/cordic/csr/ien.rs
@@ -18,5 +18,4 @@ pub fn generate() -> Field {
             ]),
         ])),
     )
-    .reset("Disabled")
 }

--- a/tests/g4/model/src/cordic/csr/nargs.rs
+++ b/tests/g4/model/src/cordic/csr/nargs.rs
@@ -18,5 +18,4 @@ pub fn generate() -> Field {
                 .docs(["Two writes are needed to the [`wdata`](super::super::wdata) register."]),
         ])),
     )
-    .reset("One")
 }

--- a/tests/g4/model/src/cordic/csr/nres.rs
+++ b/tests/g4/model/src/cordic/csr/nres.rs
@@ -18,5 +18,4 @@ pub fn generate() -> Field {
                 .docs(["Two reads are needed on the [`rdata`](super::super::rdata) register."]),
         ])),
     )
-    .reset("One")
 }

--- a/tests/g4/model/src/cordic/csr/precision.rs
+++ b/tests/g4/model/src/cordic/csr/precision.rs
@@ -15,5 +15,4 @@ pub fn generate() -> Field {
         4,
         Access::read_write(Numericity::enumerated(variants)),
     )
-    .reset("P20")
 }

--- a/tests/g4/model/src/cordic/csr/ressize.rs
+++ b/tests/g4/model/src/cordic/csr/ressize.rs
@@ -16,6 +16,5 @@ pub fn generate() -> Field {
             Variant::new("Q15", 1).docs(["1 sign bit, 15 fractional bits."]),
         ])),
     )
-    .reset("Q31")
     .docs(["The value format used for results."])
 }

--- a/tests/g4/model/src/cordic/csr/scale.rs
+++ b/tests/g4/model/src/cordic/csr/scale.rs
@@ -15,5 +15,4 @@ pub fn generate() -> Field {
         3,
         Access::read_write(Numericity::enumerated(variants)),
     )
-    .reset("N0")
 }

--- a/tests/g4/model/src/crc/cr.rs
+++ b/tests/g4/model/src/crc/cr.rs
@@ -16,4 +16,5 @@ pub fn generate() -> Register {
             rev_out::generate(),
         ],
     )
+    .reset(0)
 }

--- a/tests/g4/model/src/crc/cr/polysize.rs
+++ b/tests/g4/model/src/crc/cr/polysize.rs
@@ -18,5 +18,4 @@ pub fn generate() -> Field {
             Variant::new("P7", 3),
         ])),
     )
-    .reset(0)
 }

--- a/tests/g4/model/src/crc/cr/rev_in.rs
+++ b/tests/g4/model/src/crc/cr/rev_in.rs
@@ -18,5 +18,4 @@ pub fn generate() -> Field {
             Variant::new("Word", 3),
         ])),
     )
-    .reset("NoEffect")
 }

--- a/tests/g4/model/src/crc/cr/rev_out.rs
+++ b/tests/g4/model/src/crc/cr/rev_out.rs
@@ -16,5 +16,4 @@ pub fn generate() -> Field {
             Variant::new("Reversed", 1),
         ])),
     )
-    .reset("NoEffect")
 }

--- a/tests/g4/model/src/crc/idr.rs
+++ b/tests/g4/model/src/crc/idr.rs
@@ -10,6 +10,12 @@ pub fn generate() -> Register {
     Register::new(
         "idr",
         4,
-        [Field::new("idr", 0, 32, Access::read_write(Numericity::Numeric)).reset(0)],
+        [Field::new(
+            "idr",
+            0,
+            32,
+            Access::read_write(Numericity::Numeric),
+        )],
     )
+    .reset(0)
 }

--- a/tests/g4/model/src/rcc/ahbenr.rs
+++ b/tests/g4/model/src/rcc/ahbenr.rs
@@ -36,7 +36,7 @@ pub fn generate(instance: Instance) -> Register {
                 en::generate("dammux1en", 2),
                 en::generate("cordicen", 3),
                 en::generate("fmacen", 4),
-                en::generate("flashen", 8).reset("Enabled"),
+                en::generate("flashen", 8),
                 en::generate("crcen", 12),
             ],
             Instance::I2 => vec![
@@ -58,4 +58,8 @@ pub fn generate(instance: Instance) -> Register {
             ],
         },
     )
+    .reset(match instance {
+        Instance::I1 => 0x100,
+        Instance::I2 => 0,
+    })
 }

--- a/tests/g4/model/src/rcc/ahbenr/en.rs
+++ b/tests/g4/model/src/rcc/ahbenr/en.rs
@@ -16,5 +16,4 @@ pub fn generate(ident: impl AsRef<str>, offset: u8) -> Field {
             Variant::new("Enabled", 1),
         ])),
     )
-    .reset("Disabled")
 }

--- a/tests/g4/src/lib.rs
+++ b/tests/g4/src/lib.rs
@@ -154,4 +154,20 @@ mod tests {
             });
         }
     }
+
+    mod rcc {
+        use core::any::{Any, TypeId};
+
+        use crate::rcc;
+
+        #[test]
+        fn reset() {
+            let p = unsafe { crate::peripherals() };
+
+            assert_eq!(
+                p.rcc.ahb1enr.flashen.type_id(),
+                TypeId::of::<rcc::ahb1enr::flashen::Enabled>()
+            );
+        }
+    }
 }


### PR DESCRIPTION
Currently, users specified field resets on the `Field` type. This made sense since the states provided on reset pertain to each field. Where this starts to break down, however, is on field or register arrays. There are often register and field arrays where the register and field schema remains constant, but some reset values change depending on the array index.

This merely exposed the nature of state maintenance in general. Fields represent the structure of a register, but the actual physical thing that holds the state is the register itself, even though this state can be distributed across its fields. It is more correct to assign reset values to registers instead of fields.