### PR TITLE
improve codegen failure output with span information

### DIFF
--- a/ir/Cargo.toml
+++ b/ir/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 colored = "3.0.0"
 Inflector = "0.11.4"
-proc-macro2 = "1.0.89"
+proc-macro2 = { version = "1.0.89", features = ["span-locations"] }
 quote = "1.0.37"
 tiva = "0.3.0"
 syn = { version = "2.0.87", features = ["full"] }

--- a/proto-hal-build/src/codegen.rs
+++ b/proto-hal-build/src/codegen.rs
@@ -70,7 +70,7 @@ pub fn validate(source: impl FnOnce() -> (Hal, Diagnostics)) {
             fs::write("/tmp/erroneous-hal.rs", hal.render_raw()).unwrap();
 
             println!(
-                "{}: Codegen failed: {e}.\n{}\nErroneous codegen written to /tmp/erroneous-hal.rs",
+                "{}: Codegen failed: {e}\n{}\nErroneous codegen written to /tmp/erroneous-hal.rs",
                 "error".red().bold(),
                 "This is probably a bug, please submit an issue: https://github.com/adinack/proto-hal/issues".bold(),
             );


### PR DESCRIPTION
Display a snippet of the erroneous output in addition to the parsing error.