### PR TITLE
curly braces around numeric transition exprs

### DIFF
--- a/build/src/macros/gates/fragments/transition_return_ty.rs
+++ b/build/src/macros/gates/fragments/transition_return_ty.rs
@@ -49,7 +49,7 @@ pub fn transition_return_ty(
                     // once the variant is complete, this will be handled
                     // in the `Variant` arm
                     let state = if let Some(numeric_ty) = numeric_ty {
-                        quote! { ::proto_hal::stasis::#numeric_ty<#expr> }
+                        quote! { ::proto_hal::stasis::#numeric_ty<{#expr}> }
                     } else {
                         quote! { #peripheral_path::#register_ident::#field_ident::#expr }
                     };


### PR DESCRIPTION
The user would often need to do this anyway so we might as well include them invariably.