### PR TITLE
non default interrupts

### DIFF
--- a/build/Cargo.toml
+++ b/build/Cargo.toml
@@ -15,7 +15,7 @@ syn = { workspace = true }
 ters = { workspace = true }
 
 [features]
-default = ["integrated", "interrupts"]
+default = ["integrated"]
 macros = []
 integrated = []
 interrupts = []


### PR DESCRIPTION
Interrupt vector table generation (device.x) should be opt-in.